### PR TITLE
Add feature to create a vault on new user sign-up

### DIFF
--- a/lib/database_persistence.rb
+++ b/lib/database_persistence.rb
@@ -30,7 +30,14 @@ class DatabasePersistence
 
   # Delete all tables
   def delete_all_data
-    @db.exec "DELETE FROM users; ALTER SEQUENCE users_id_seq RESTART;"
+    sql = <<~SQL
+    DELETE FROM users;
+    ALTER SEQUENCE users_id_seq RESTART;
+    DELETE FROM vaults;
+    ALTER SEQUENCE vaults_id_seq RESTART;
+    SQL
+
+    @db.exec(sql)
   end
 
   # Add a vault associated with a user based on the given username

--- a/lib/database_persistence.rb
+++ b/lib/database_persistence.rb
@@ -42,6 +42,22 @@ class DatabasePersistence
     query(sql, user_id, vault_name)
   end
 
+  # Find a vault with the given vault name of a specific user
+  def find_vault(username, vault_name)
+    user = find_user(username)
+    return unless user
+    user_id = user["id"]
+
+    sql = <<~SQL
+    SELECT * FROM vaults
+    WHERE user_id = $1
+    AND name ILIKE $2
+    SQL
+
+    result = query(sql, user_id, vault_name)
+    result.first
+  end
+
   private
 
   def query(statement, *params)

--- a/lib/database_persistence.rb
+++ b/lib/database_persistence.rb
@@ -33,6 +33,15 @@ class DatabasePersistence
     @db.exec "DELETE FROM users; ALTER SEQUENCE users_id_seq RESTART;"
   end
 
+  # Add a vault associated with a user based on the given username
+  def add_vault(username, vault_name)
+    user = find_user(username)
+    user_id = user["id"]
+
+    sql = "INSERT INTO vaults (user_id, name) VALUES ($1, $2)"
+    query(sql, user_id, vault_name)
+  end
+
   private
 
   def query(statement, *params)

--- a/lib/database_persistence.rb
+++ b/lib/database_persistence.rb
@@ -40,27 +40,15 @@ class DatabasePersistence
     @db.exec(sql)
   end
 
-  # Add a vault associated with a user based on the given username
-  def add_vault(username, vault_name)
-    user = find_user(username)
-    user_id = user["id"]
-
+  # Add a vault associated with a user based on the given user id
+  def add_vault(user_id, vault_name)
     sql = "INSERT INTO vaults (user_id, name) VALUES ($1, $2)"
     query(sql, user_id, vault_name)
   end
 
   # Find a vault with the given vault name of a specific user
-  def find_vault(username, vault_name)
-    user = find_user(username)
-    return unless user
-    user_id = user["id"]
-
-    sql = <<~SQL
-    SELECT * FROM vaults
-    WHERE user_id = $1
-    AND name ILIKE $2
-    SQL
-
+  def find_vault(user_id, vault_name)
+    sql = "SELECT * FROM vaults WHERE user_id = $1 AND name ILIKE $2"
     result = query(sql, user_id, vault_name)
     result.first
   end

--- a/lib/password_manager.rb
+++ b/lib/password_manager.rb
@@ -77,6 +77,11 @@ post "/users" do
   else
     password_hash = BCrypt::Password.create(password)
     @storage.add_user(username, password_hash)
+
+    user = @storage.find_user(username)
+    user_id = user["id"]
+    @storage.add_vault(user_id, "My Vault")
+
     session[:user] = username
   end
 end

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -6,3 +6,11 @@ CREATE TABLE IF NOT EXISTS users (
   updated_at timestamp NOT NULL DEFAULT now(),
   UNIQUE (username, password_hash)
 );
+
+CREATE TABLE IF NOT EXISTS vaults (
+  id serial PRIMARY KEY,
+  name varchar(100) NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now(),
+  user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE
+);

--- a/test/password_manager_test.rb
+++ b/test/password_manager_test.rb
@@ -165,4 +165,22 @@ class PasswordManagerTest < Minitest::Test
     assert vault2
     assert_equal "1", vault2["id"]
   end
+
+  def test_add_vault_with_valid_user_id
+    @storage.add_user("admin", "123")
+    @storage.add_vault(1, "My Vault")
+
+    vault = @storage.find_vault(1, "My Vault")
+    assert vault
+    assert_equal "1", vault["user_id"]
+    assert_equal "My Vault", vault["name"]
+  end
+
+  def test_add_vault_without_valid_user_id
+    assert_raises PG::ForeignKeyViolation do
+      @storage.add_vault(1, "My Vault")
+    end
+
+    assert_nil @storage.find_vault(1, "My Vault")
+  end
 end

--- a/test/password_manager_test.rb
+++ b/test/password_manager_test.rb
@@ -183,4 +183,17 @@ class PasswordManagerTest < Minitest::Test
 
     assert_nil @storage.find_vault(1, "My Vault")
   end
+
+  def test_find_vault_with_valid_user_id
+    @storage.add_user("admin", "123")
+    @storage.add_vault(1, "My Vault")
+
+    assert @storage.find_vault(1, "My Vault")
+    assert @storage.find_vault(1, "my vault")
+    assert_nil @storage.find_vault(1, "test vault")
+  end
+
+  def test_find_vault_without_valid_user_id
+    assert_nil @storage.find_vault(1, "my vault")
+  end
 end

--- a/test/password_manager_test.rb
+++ b/test/password_manager_test.rb
@@ -137,19 +137,32 @@ class PasswordManagerTest < Minitest::Test
 
   def test_delete_all_data
     @storage.add_user("admin", "123")
+    @storage.add_vault("admin", "My Vault")
 
     user1 = @storage.find_user("admin")
+    vault1 = @storage.find_vault("admin", "my vault")
+
     assert user1
     assert_equal "1", user1["id"]
+    assert_equal "1", vault1["id"]
+    assert_equal vault1["user_id"], user1["id"]
+    assert_equal "My Vault", vault1["name"]
 
     @storage.delete_all_data
 
+    assert_nil @storage.find_vault("admin", "my vault")
     assert_nil @storage.find_user("admin")
 
     @storage.add_user("developer", "123")
+    @storage.add_vault("developer", "My Vault")
 
     user2 = @storage.find_user("developer")
+    vault2 = @storage.find_vault("developer", "my vault")
+
     assert user2
     assert_equal "1", user2["id"]
+    assert_equal "1", vault2["id"]
+    assert_equal vault2["user_id"], user2["id"]
+    assert_equal "My Vault", vault2["name"]
   end
 end

--- a/test/password_manager_test.rb
+++ b/test/password_manager_test.rb
@@ -76,6 +76,15 @@ class PasswordManagerTest < Minitest::Test
     assert_nil Validatable.error_for_invalid_password("admin", "secret", @storage)
   end
 
+  def test_create_vault_on_sign_up
+    post "/users", { username: "admin", password: "secret", repeat_password: "secret" }
+
+    assert_equal 200, last_response.status
+
+    user = @storage.find_user("admin")
+    assert @storage.find_vault(user["id"], "My Vault")
+  end
+
   def test_sign_in_form
     get "/users/sign-in"
 

--- a/test/password_manager_test.rb
+++ b/test/password_manager_test.rb
@@ -137,32 +137,32 @@ class PasswordManagerTest < Minitest::Test
 
   def test_delete_all_data
     @storage.add_user("admin", "123")
-    @storage.add_vault("admin", "My Vault")
+    @storage.add_vault(1, "My Vault")
 
     user1 = @storage.find_user("admin")
-    vault1 = @storage.find_vault("admin", "my vault")
+    vault1 = @storage.find_vault(1, "My vault")
 
     assert user1
     assert_equal "1", user1["id"]
+
+    assert vault1
     assert_equal "1", vault1["id"]
-    assert_equal vault1["user_id"], user1["id"]
-    assert_equal "My Vault", vault1["name"]
 
     @storage.delete_all_data
 
-    assert_nil @storage.find_vault("admin", "my vault")
     assert_nil @storage.find_user("admin")
+    assert_nil @storage.find_vault(1, "My Vault")
 
     @storage.add_user("developer", "123")
-    @storage.add_vault("developer", "My Vault")
+    @storage.add_vault(1, "My Vault")
 
     user2 = @storage.find_user("developer")
-    vault2 = @storage.find_vault("developer", "my vault")
+    vault2 = @storage.find_vault(1, "My Vault")
 
     assert user2
     assert_equal "1", user2["id"]
+
+    assert vault2
     assert_equal "1", vault2["id"]
-    assert_equal vault2["user_id"], user2["id"]
-    assert_equal "My Vault", vault2["name"]
   end
 end


### PR DESCRIPTION
Features
- Add functionality that creates a new vault associated with the new user upon successful sign-up

User Vaults
- Update the schema to include a `vaults` table
- Add vaults that are only associated with an existing user id in the `users` table
- Return an error if a vault with a nonexistent user id is added
- Find vaults that are associated with a given user id and match the given vault name (non-case sensitive)
- Return `nil` if vaults do not match the given vault name or are associated with a nonexistent user id

User Sign-up
- Create a vault associated with the new user id upon user sign-up

Tests
- Test for vault addition
- Test for vault retrieval
- Update test for removal of all data 