### PR TITLE
Add features to store user-given credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore rubocop file
 .rubocop.yml
+
+# Ignore encryption key file
+lib/encryption_key.yml

--- a/app.rb
+++ b/app.rb
@@ -105,3 +105,22 @@ end
 get "/:username/passwords/add", require_auth: true do
   erb :new_credentials
 end
+
+# Add a new set of credentials to the database
+post "/:username/passwords", require_auth: true do
+  credentials = Credentials.create(
+    user_id: session[:user_id],
+    name: params[:entry_name],
+    username: params[:entry_username],
+    password: params[:entry_password],
+    notes: params[:entry_notes]
+  )
+
+  if credentials.error?
+    status 422
+    session[:message] = credentials.error_messages
+    erb :new_credentials
+  else
+    redirect "/#{session[:username]}"
+  end
+end

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require "tilt/erubis"
 
 require_relative "lib/database_accessor"
 require_relative "lib/user"
+require_relative "lib/credentials"
 
 def save_user_info_in_session(user)
   session[:user_id] = user.id
@@ -23,7 +24,7 @@ configure :development do
   require "sinatra/reloader"
   also_reload "database_accessor.rb"
   also_reload "user.rb"
-  also_reload "vault.rb"
+  also_reload "credentials.rb"
 end
 
 set(:require_auth) do |authenticated|

--- a/app.rb
+++ b/app.rb
@@ -101,7 +101,7 @@ get "/:username", require_auth: true do
   erb :dashboard
 end
 
-# Render form to store a new password
-get "/:username/add_password", require_auth: true do
+# Render form to store a new set of credentials
+get "/:username/passwords/add", require_auth: true do
   erb :new_credentials
 end

--- a/app.rb
+++ b/app.rb
@@ -99,3 +99,8 @@ end
 get "/:username", require_auth: true do
   erb :dashboard
 end
+
+# Render form to store a new password
+get "/:username/add_password", require_auth: true do
+  erb :new_credentials
+end

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -1,0 +1,30 @@
+require "openssl"
+require_relative "database_object"
+
+class Credentials < DatabaseObject
+  @@cipher = OpenSSL::Cipher.new('AES-256-CBC')
+
+  def initialize(*options)
+    super(*options)
+    generate_key
+  end
+
+  private
+
+  def file_path
+    if ENV["RACK_ENV"] == "test"
+      File.expand_path("../test/encryption_key.yml", __dir__)
+    else
+      File.expand_path("encryption_key.yml", __dir__)
+    end
+  end
+
+  def generate_key
+    if File.file?(file_path)
+      @@key = File.read(file_path)
+    else
+      @@key = @@cipher.random_key
+      File.write(file_path, @@key)
+    end
+  end
+end

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -105,7 +105,7 @@ class Credentials < DatabaseObject
     @encrypted_password = Base64.encode64(@encrypted_password)
   end
 
-  # Add an error if the name is not between 1-64 characters
+  # Update `@errors` if the name is not between 1-64 characters
   def name_validation
     name_error = {
       regexp: "^.{1,64}$",
@@ -116,7 +116,7 @@ class Credentials < DatabaseObject
     errors.add(:invalid_name, name_error[:message])
   end
 
-  # Add an error if the username is not between 2-256 characters
+  # Update `@errors` if the username is not between 2-256 characters
   def username_validation
     username_error = {
       regexp: "^.{2,256}$",

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -29,10 +29,10 @@ class Credentials < DatabaseObject
     values = [@user_id, name, username, @encrypted_password, @iv, @notes]
 
     sql = <<~SQL
-      INSERT INTO credentials (#{keys.join(', ')})
-      VALUES ($1, $2, $3, $4, $5, $6)
-      RETURNING id
-      SQL
+    INSERT INTO credentials (#{keys.join(', ')})
+    VALUES ($1, $2, $3, $4, $5, $6)
+    RETURNING id
+    SQL
 
     result = DatabaseAccessor.query(sql, *values)
     @id = result.first["id"].to_i

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -12,6 +12,19 @@ class Credentials < DatabaseObject
     generate_key
   end
 
+  # If the credentials set is not unique or has an invalid name/username,
+  # return the `Credentials` object with the updated `Errors` instance
+  # Otherwise, add the credentials to the database and return the instance
+  def self.create(*options)
+    credentials = new(*options)
+    return credentials unless credentials.unique?
+    credentials.validate(:name, :username)
+    return credentials if credentials.error?
+
+    credentials.add
+    credentials
+  end
+
   # Find a record with a matching name and username
   # If a record is found, return a `Credential` instance with the relevant data
   # If not, return `nil`

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -2,6 +2,8 @@ require "openssl"
 require_relative "database_object"
 
 class Credentials < DatabaseObject
+  attr_reader :errors, :name
+
   @@cipher = OpenSSL::Cipher.new('AES-256-CBC')
 
   def initialize(*options)
@@ -26,5 +28,16 @@ class Credentials < DatabaseObject
       @@key = @@cipher.random_key
       File.write(file_path, @@key)
     end
+  end
+
+  # Add an error if the name is not between 1-64 characters
+  def name_validation
+    name_error = {
+      regexp: "^.{1,64}$",
+      message: "Name should have between 1 and 64 characters."
+    }
+
+    return if name =~ /#{name_error[:regexp]}/
+    errors.add(:invalid_name, name_error[:message])
   end
 end

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -11,6 +11,17 @@ class Credentials < DatabaseObject
     generate_key
   end
 
+  # Find a record with a matching name and username
+  # If a record is found, return a `Credential` instance with the relevant data
+  # If not, return `nil`
+  def self.find_by_name_and_username(name, username)
+    sql = "SELECT * FROM credentials WHERE name = $1 AND username = $2"
+    result = DatabaseAccessor.query(sql, name, username)
+    tuple = result.first
+
+    new(tuple) if tuple
+  end
+
   def add
     keys = ["user_id", "name", "username", "encrypted_password", "iv", "notes"]
     values = [@user_id, name, username, @encrypted_password, @iv, @notes]

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -40,7 +40,7 @@ class Credentials < DatabaseObject
   # Add a new credentials set to the `credentials` table
   # Return the `id` of the inserted record and assign it to `@id`
   def add
-    encrypt_password if @password
+    encrypt_password unless @password.nil? || @password.empty?
 
     keys = ["user_id", "name", "username", "encrypted_password", "iv", "notes"]
     values = [@user_id, name, username, @encrypted_password, @iv, @notes]

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -2,7 +2,7 @@ require "openssl"
 require_relative "database_object"
 
 class Credentials < DatabaseObject
-  attr_reader :errors, :name
+  attr_reader :errors, :name, :username
 
   @@cipher = OpenSSL::Cipher.new('AES-256-CBC')
 
@@ -39,5 +39,16 @@ class Credentials < DatabaseObject
 
     return if name =~ /#{name_error[:regexp]}/
     errors.add(:invalid_name, name_error[:message])
+  end
+
+  # Add an error if the username is not between 2-256 characters
+  def username_validation
+    username_error = {
+      regexp: "^.{2,256}$",
+      message: "Username should have between 2 and 256 characters."
+    }
+
+    return if username =~ /#{username_error[:regexp]}/
+    errors.add(:invalid_username, username_error[:message])
   end
 end

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -11,6 +11,18 @@ class Credentials < DatabaseObject
     generate_key
   end
 
+  def add
+    keys = ["user_id", "name", "username", "encrypted_password", "iv", "notes"]
+    values = [@user_id, name, username, @encrypted_password, @iv, @notes]
+
+    sql = <<~SQL
+      INSERT INTO credentials (#{keys.join(', ')})
+      VALUES ($1, $2, $3, $4, $5, $6)
+      SQL
+
+    DatabaseAccessor.query(sql, *values)
+  end
+
   private
 
   def file_path

--- a/lib/credentials.rb
+++ b/lib/credentials.rb
@@ -22,6 +22,8 @@ class Credentials < DatabaseObject
     new(tuple) if tuple
   end
 
+  # Add a new credentials set to the `credentials` table
+  # Return the `id` of the inserted record and assign it to `@id`
   def add
     keys = ["user_id", "name", "username", "encrypted_password", "iv", "notes"]
     values = [@user_id, name, username, @encrypted_password, @iv, @notes]
@@ -29,9 +31,11 @@ class Credentials < DatabaseObject
     sql = <<~SQL
       INSERT INTO credentials (#{keys.join(', ')})
       VALUES ($1, $2, $3, $4, $5, $6)
+      RETURNING id
       SQL
 
-    DatabaseAccessor.query(sql, *values)
+    result = DatabaseAccessor.query(sql, *values)
+    @id = result.first["id"].to_i
   end
 
   private

--- a/lib/database_accessor.rb
+++ b/lib/database_accessor.rb
@@ -19,7 +19,9 @@ class DatabaseAccessor
 
     sql = <<~SQL
     DELETE FROM users;
+    DELETE FROM credentials;
     ALTER SEQUENCE users_id_seq RESTART;
+    ALTER SEQUENCE credentials_id_seq RESTART;
     SQL
 
     @@db.exec(sql)

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -6,3 +6,14 @@ CREATE TABLE IF NOT EXISTS users (
   updated_at timestamp NOT NULL DEFAULT now(),
   UNIQUE (username, password_hash)
 );
+
+CREATE TABLE IF NOT EXISTS credentials (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  username text NOT NULL,
+  encrypted_password text,
+  iv text,
+  notes text,
+  UNIQUE(name, username)
+);

--- a/lib/schema.sql
+++ b/lib/schema.sql
@@ -15,5 +15,7 @@ CREATE TABLE IF NOT EXISTS credentials (
   encrypted_password text,
   iv text,
   notes text,
-  UNIQUE(name, username)
+  UNIQUE(name, username),
+  CHECK (length(name) BETWEEN 1 AND 64),
+  CHECK (length(username) BETWEEN 2 AND 256)
 );

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -7,7 +7,8 @@ dd {
 }
 
 form input[type="text"],
-form input[type="password"] {
+form input[type="password"],
+form textarea {
   width: 70%
 }
 

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -170,4 +170,16 @@ class AppTest < Minitest::Test
 
     assert_equal 200, last_response.status
   end
+
+  def test_add_new_credentials_form
+    get "/admin/passwords/add", {}, admin_session
+
+    assert_equal 200, last_response.status
+    assert_includes last_response.body, %q(form action="/admin/passwords" method="post")
+    assert_includes last_response.body, %q(input id="entry_name")
+    assert_includes last_response.body, %q(input id="entry_username")
+    assert_includes last_response.body, %q(input id="entry_password")
+    assert_includes last_response.body, %q(textarea id="entry_notes")
+    assert_includes last_response.body, %q(input type="submit")
+  end
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -180,6 +180,6 @@ class AppTest < Minitest::Test
     assert_includes last_response.body, %q(input id="entry_username")
     assert_includes last_response.body, %q(input id="entry_password")
     assert_includes last_response.body, %q(textarea id="entry_notes")
-    assert_includes last_response.body, %q(input type="submit")
+    assert_includes last_response.body, %q(button type="submit")
   end
 end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -182,4 +182,45 @@ class AppTest < Minitest::Test
     assert_includes last_response.body, %q(textarea id="entry_notes")
     assert_includes last_response.body, %q(button type="submit")
   end
+
+  def test_add_new_credentials_with_invalid_name
+    credentials = { entry_name: "", entry_username: "johndoe" }
+    User.add("admin", "test123")
+
+    post "/admin/passwords", credentials, admin_session
+
+    assert_equal 422, last_response.status
+    assert_includes last_response.body, "Name should have between 1 and 64 characters."
+  end
+
+  def test_add_credentials_with_invalid_username
+    credentials = { entry_name: "Example.com", entry_username: "a" }
+    User.add("admin", "test123")
+
+    post "/admin/passwords", credentials, admin_session
+
+    assert_equal 422, last_response.status
+    assert_includes last_response.body, "Username should have between 2 and 256 characters."
+  end
+
+  def test_add_nonunique_credentials
+    credentials = { entry_name: "Example.com", entry_username: "johndoe" }
+    User.add("admin", "test123")
+
+    post "/admin/passwords", credentials, admin_session
+    post "/admin/passwords", credentials, admin_session
+
+    assert_equal 422, last_response.status
+    assert_includes last_response.body, "An entry with this name and username already exists."
+  end
+
+  def test_add_valid_new_credentials
+    credentials = { entry_name: "Example.com", entry_username: "johndoe" }
+    User.add("admin", "test123")
+
+    post "/admin/passwords", credentials, admin_session
+
+    assert_equal 302, last_response.status
+    assert_match /\/admin$/, last_response["Location"]
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -19,7 +19,7 @@ class CredentialsTest < Minitest::Test
   def teardown
     DatabaseAccessor.reset
     DatabaseAccessor.disconnect
-    FileUtils.rm(encryption_file_path)
+    FileUtils.rm_f(encryption_file_path)
   end
 
   def test_generate_key_on_instantiation

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -88,4 +88,18 @@ class CredentialsTest < Minitest::Test
     not_found = Credentials.find_by_name_and_username("Example.org", "johndoe")
     assert_nil not_found
   end
+
+  def test_unique_credentials
+    credentials1 = Credentials.new(user_id: 1, name: "Example.com", username: "johndoe")
+    assert credentials1.unique?
+    refute credentials1.error?
+
+    credentials1.add
+    assert credentials1.unique?
+
+    credentials2 = Credentials.new(user_id: 1, name: "Example.com", username: "johndoe")
+    refute credentials2.unique?
+    assert credentials2.error?
+    assert_equal "An entry with this name and username already exists.", credentials2.error_messages
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -1,0 +1,27 @@
+ENV["RACK_ENV"] = "test"
+
+require "minitest/autorun"
+
+require_relative "../lib/credentials"
+require_relative "../lib/database_accessor"
+
+class CredentialsTest < Minitest::Test
+  def setup
+    DatabaseAccessor.connect
+  end
+
+  def encryption_file_path
+    File.expand_path("encryption_key.yml", __dir__)
+  end
+
+  def teardown
+    DatabaseAccessor.reset
+    DatabaseAccessor.disconnect
+    FileUtils.rm(encryption_file_path)
+  end
+
+  def test_generate_key_on_instantiation
+    Credentials.new
+    assert File.file?(encryption_file_path)
+  end
+end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -24,4 +24,16 @@ class CredentialsTest < Minitest::Test
     Credentials.new
     assert File.file?(encryption_file_path)
   end
+
+  def test_wrong_name_length
+    credentials = Credentials.new(name: "")
+    credentials.validate(:name)
+    assert credentials.error?
+    assert_equal "Name should have between 1 and 64 characters.", credentials.error_messages
+
+    credentials = Credentials.new(name: "a" * 65)
+    credentials.validate(:name)
+    assert credentials.error?
+    assert_equal "Name should have between 1 and 64 characters.", credentials.error_messages
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -102,4 +102,13 @@ class CredentialsTest < Minitest::Test
     assert credentials2.error?
     assert_equal "An entry with this name and username already exists.", credentials2.error_messages
   end
+
+  def test_encrypt_password
+    credentials = Credentials.new(password: "test123")
+    assert_equal "test123", credentials.instance_variable_get(:@password)
+
+    credentials.encrypt_password
+    assert_nil credentials.instance_variable_get(:@password)
+    refute_equal "test123", credentials.instance_variable_get(:@encrypted_password)
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -112,12 +112,27 @@ class CredentialsTest < Minitest::Test
     refute_equal "test123", credentials.instance_variable_get(:@encrypted_password)
   end
 
-  def test_create_valid_credentials
-    Credentials.create(user_id: 1, name: "Example.com", username: "johndoe")
+  def test_create_valid_credentials_with_password
+    Credentials.create(user_id: 1, name: "Example.com", username: "johndoe", password: "test123")
     found = Credentials.find_by_name_and_username("Example.com", "johndoe")
+
     assert found
     assert_equal "Example.com", found.name
     assert_equal "johndoe", found.username
+    assert found.instance_variable_get(:@encrypted_password)
+    assert found.instance_variable_get(:@iv)
+    refute_equal "test123", found.instance_variable_get(:@encrypted_password)
+  end
+
+  def test_create_valid_credentials_without_password
+    Credentials.create(user_id: 1, name: "Example.com", username: "johndoe", password: "")
+    found = Credentials.find_by_name_and_username("Example.com", "johndoe")
+
+    assert found
+    assert_equal "Example.com", found.name
+    assert_equal "johndoe", found.username
+    assert_nil found.instance_variable_get(:@encrypted_password)
+    assert_nil found.instance_variable_get(:@iv)
   end
 
   def test_create_credentials_with_nonunique_entry

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -111,4 +111,36 @@ class CredentialsTest < Minitest::Test
     assert_nil credentials.instance_variable_get(:@password)
     refute_equal "test123", credentials.instance_variable_get(:@encrypted_password)
   end
+
+  def test_create_valid_credentials
+    Credentials.create(user_id: 1, name: "Example.com", username: "johndoe")
+    found = Credentials.find_by_name_and_username("Example.com", "johndoe")
+    assert found
+    assert_equal "Example.com", found.name
+    assert_equal "johndoe", found.username
+  end
+
+  def test_create_credentials_with_nonunique_entry
+    Credentials.create(user_id: 1, name: "A.com", username: "test")
+    credentials = Credentials.create(user_id: 1, name: "A.com", username: "test")
+
+    assert credentials.error?
+    assert_equal "An entry with this name and username already exists.", credentials.error_messages
+  end
+
+  def test_create_credentials_with_invalid_name
+    credentials = Credentials.create(name: "", user_id: 1, username: "test")
+
+    assert credentials.error?
+    assert_equal "Name should have between 1 and 64 characters.", credentials.error_messages
+    assert_nil Credentials.find_by_name_and_username("", "test")
+  end
+
+  def test_create_credentials_with_invalid_username
+    credentials = Credentials.create(username: "a", user_id: 1, name: "A.com")
+
+    assert credentials.error?
+    assert_equal "Username should have between 2 and 256 characters.", credentials.error_messages
+    assert_nil Credentials.find_by_name_and_username("A.com", "a")
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -74,4 +74,18 @@ class CredentialsTest < Minitest::Test
       credentials.add
     end
   end
+
+  def test_find_existing_credentials_by_name_and_username
+    credentials = Credentials.new(user_id: 1, name: "Example.com", username: "johndoe")
+    credentials.add
+    found = Credentials.find_by_name_and_username("Example.com", "johndoe")
+
+    assert_equal "Example.com", found.name
+    assert_equal "johndoe", found.username
+  end
+
+  def test_find_nonexistent_credentials
+    not_found = Credentials.find_by_name_and_username("Example.org", "johndoe")
+    assert_nil not_found
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -36,4 +36,16 @@ class CredentialsTest < Minitest::Test
     assert credentials.error?
     assert_equal "Name should have between 1 and 64 characters.", credentials.error_messages
   end
+
+  def test_wrong_username_length
+    credentials = Credentials.new(username: "a")
+    credentials.validate(:username)
+    assert credentials.error?
+    assert_equal "Username should have between 2 and 256 characters.", credentials.error_messages
+
+    credentials = Credentials.new(username: "a" * 257)
+    credentials.validate(:username)
+    assert credentials.error?
+    assert_equal "Username should have between 2 and 256 characters.", credentials.error_messages
+  end
 end

--- a/test/credentials_test.rb
+++ b/test/credentials_test.rb
@@ -4,10 +4,12 @@ require "minitest/autorun"
 
 require_relative "../lib/credentials"
 require_relative "../lib/database_accessor"
+require_relative "../lib/user"
 
 class CredentialsTest < Minitest::Test
   def setup
     DatabaseAccessor.connect
+    User.add("johndoe", "test123")
   end
 
   def encryption_file_path
@@ -47,5 +49,29 @@ class CredentialsTest < Minitest::Test
     credentials.validate(:username)
     assert credentials.error?
     assert_equal "Username should have between 2 and 256 characters.", credentials.error_messages
+  end
+
+  def test_add_wrong_name_length
+    credentials = Credentials.new(name: "", user_id: 1, username: "johndoe")
+    assert_raises PG::CheckViolation do
+      credentials.add
+    end
+
+    credentials = Credentials.new(name: "a" * 65, user_id: 1, username: "johndoe")
+    assert_raises PG::CheckViolation do
+      credentials.add
+    end
+  end
+
+  def test_add_wrong_username_length
+    credentials = Credentials.new(username: "a", user_id: 1, name: "Example.com")
+    assert_raises PG::CheckViolation do
+      credentials.add
+    end
+
+    credentials = Credentials.new(username: "a" * 257, user_id: 1, name: "Example.com")
+    assert_raises PG::CheckViolation do
+      credentials.add
+    end
   end
 end

--- a/test/database_accessor_test.rb
+++ b/test/database_accessor_test.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 
 require_relative "../lib/database_accessor"
 require_relative "../lib/user"
+require_relative "../lib/credentials"
 
 class DatabaseAccessorTest < Minitest::Test
   def setup
@@ -17,21 +18,32 @@ class DatabaseAccessorTest < Minitest::Test
 
   def test_delete_all_data
     User.add("admin", "123")
+    Credentials.new(user_id: 1, name: "Example.com", username: "johndoe").add
 
     user1 = User.find_by_username("admin")
+    credentials1 = Credentials.find_by_name_and_username("Example.com", "johndoe")
 
     assert user1
     assert_equal 1, user1.id
 
+    assert credentials1
+    assert_equal 1, credentials1.id
+
     DatabaseAccessor.reset
 
     assert_nil User.find_by_username("admin")
+    assert_nil Credentials.find_by_name_and_username("Example.com", "johndoe")
 
     User.add("developer", "123")
+    Credentials.new(user_id: 1, name: "Example.org", username: "johndoe").add
 
     user2 = User.find_by_username("developer")
+    credentials2 = Credentials.find_by_name_and_username("Example.org", "johndoe")
 
     assert user2
     assert_equal 1, user2.id
+
+    assert credentials2
+    assert_equal 1, credentials2.id
   end
 end

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,2 +1,2 @@
 <p>You have no stored passwords.</p>
-<p><a href="/<%= params[:username] %>/add_password">Add a new password.</a></p>
+<p><a href="/<%= params[:username] %>/passwords/add">Add a new password.</a></p>

--- a/views/new_credentials.erb
+++ b/views/new_credentials.erb
@@ -26,8 +26,7 @@
       <label for="entry_password">Password</label>
     </dt>
     <dd>
-      <input id="entry_password" name="entry_password" type="password" placeholder="Enter your login password"
-      required>
+      <input id="entry_password" name="entry_password" type="password" placeholder="Enter your login password">
     </dd>
   </dl>
 

--- a/views/new_credentials.erb
+++ b/views/new_credentials.erb
@@ -40,6 +40,6 @@
     </dd>
   </dl>
 
-  <input type="submit" value="Save">
+  <button type="submit">Save</button>
   <a href="/<%= params[:username] %>">Cancel</a>
 </form>

--- a/views/new_credentials.erb
+++ b/views/new_credentials.erb
@@ -7,7 +7,7 @@
     </dt>
     <dd>
       <input id="entry_name" name="entry_name" type="text" placeholder="Enter the name of the website or service"
-       value="<% params[:entry_name] %>" required>
+       value="<%= params[:entry_name] %>" required>
     </dd>
   </dl>
 

--- a/views/new_credentials.erb
+++ b/views/new_credentials.erb
@@ -1,0 +1,45 @@
+<h2>Add a new password</h2>
+
+<form action="/<%= params[:username] %>/passwords" method="post">
+  <dl>
+    <dt>
+      <label for="entry_name">Name</label>
+    </dt>
+    <dd>
+      <input id="entry_name" name="entry_name" type="text" placeholder="Enter the name of the website or service"
+       value="<% params[:entry_name] %>" required>
+    </dd>
+  </dl>
+
+  <dl>
+    <dt>
+      <label for="entry_username">Username</label>
+    </dt>
+    <dd>
+      <input id="entry_username" name="entry_username" type="text"
+       placeholder="Enter your login username or email" value="<%= params[:entry_username] %>" required>
+    </dd>
+  </dl>
+
+  <dl>
+    <dt>
+      <label for="entry_password">Password</label>
+    </dt>
+    <dd>
+      <input id="entry_password" name="entry_password" type="password" placeholder="Enter your login password"
+      required>
+    </dd>
+  </dl>
+
+  <dl>
+    <dt>
+      <label for="entry_notes">Notes</label>
+    </dt>
+    <dd>
+      <textarea id="entry_notes" name="entry_notes" rows="5" cols="80"></textarea>
+    </dd>
+  </dl>
+
+  <input type="submit" value="Save">
+  <a href="/<%= params[:username] %>">Cancel</a>
+</form>


### PR DESCRIPTION
Features
- Add functionality for users to add a new set of credentials to the database
- Create a new `Credentials` class that encapsulates logic for creation, validation, encryption, and retrieval of credentials

Credentials
- Create and add data from a `Credentials` object upon successful validation
- Encrypt password of the given credentials if needed
- Return a `Credentials` instance with its `Errors` collaborator object updated with the appropriate error type

Tests
- Test for the proper rendering of the form to add new credentials
- Test for error handling during the creation of a credentials entry
- Test for database update during successful creation of credentials 

